### PR TITLE
`pool_admin` tests

### DIFF
--- a/src/behaviors/deployer.rs
+++ b/src/behaviors/deployer.rs
@@ -54,7 +54,7 @@ impl Behavior<()> for Deployer {
     }
 }
 
-async fn deploy_factory(
+pub async fn deploy_factory(
     client: &Arc<ArbiterMiddleware>,
 ) -> Result<UniswapV3Factory<ArbiterMiddleware>> {
     UniswapV3Factory::deploy(client.clone(), ())
@@ -64,7 +64,7 @@ async fn deploy_factory(
         .map_err(|e| anyhow!("Failed to send factory deployment: {}", e))
 }
 
-async fn deploy_liquid_exchange(
+pub async fn deploy_liquid_exchange(
     client: &Arc<ArbiterMiddleware>,
 ) -> Result<LiquidExchange<ArbiterMiddleware>> {
     LiquidExchange::deploy(client.clone(), ())

--- a/src/behaviors/pool_admin.rs
+++ b/src/behaviors/pool_admin.rs
@@ -71,3 +71,116 @@ impl Behavior<Message> for PoolAdmin {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use anyhow::Result;
+    use arbiter_bindings::bindings::arbiter_token::ArbiterToken;
+    use arbiter_core::middleware::ArbiterMiddleware;
+    use arbiter_engine::{
+        agent::Agent,
+        machine::{Behavior, EventStream},
+        messager::{Messager, To},
+        world::World,
+    };
+    use ethers::middleware::Middleware;
+    use serde::{Deserialize, Serialize};
+
+    use crate::behaviors::{
+        deployer::deploy_factory,
+        pool_admin::{PoolAdmin, PoolCreation},
+    };
+
+    #[derive(Debug, Deserialize, Serialize)]
+    pub struct MockDeployer {}
+
+    /// Behaviour initialized after mock agents have run to assert assumptions about their execution.
+    #[derive(Debug, Deserialize, Serialize)]
+    pub struct Asserter {}
+
+    #[async_trait::async_trait]
+    impl Behavior<()> for MockDeployer {
+        async fn startup(
+            &mut self,
+            client: Arc<ArbiterMiddleware>,
+            messager: Messager,
+        ) -> Result<Option<EventStream<()>>> {
+            let factory = deploy_factory(&client.clone()).await?;
+
+            let token_0 = ArbiterToken::deploy(
+                client.clone(),
+                ("Token 0".to_string(), "TKN0".to_string(), 18_u8),
+            )?
+            .send()
+            .await?;
+
+            let token_1 =
+                ArbiterToken::deploy(client, ("Token 1".to_string(), "TKN1".to_string(), 18_u8))?
+                    .send()
+                    .await?;
+
+            let pool_creation_request = PoolCreation {
+                factory: factory.address(),
+                token_0: token_0.address(),
+                token_1: token_1.address(),
+                fee: 100,
+            };
+
+            messager
+                .send(To::All, serde_json::to_string(&pool_creation_request)?)
+                .await?;
+
+            Ok(None)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Behavior<()> for Asserter {
+        async fn startup(
+            &mut self,
+            client: Arc<ArbiterMiddleware>,
+            _messager: Messager,
+        ) -> Result<Option<EventStream<()>>> {
+            let accounts = client.get_accounts().await?;
+
+            // it is enough to assert that the accounts have been created.
+            assert!(accounts.len() == 5, "actual length: {}", accounts.len());
+
+            Ok(None)
+        }
+    }
+
+    #[tokio::test]
+    async fn pool_admin_behaviour_test() {
+        let mut world = World::new("univ3");
+
+        // messager and client are initialized later.
+        let pool_admin_behaviour = PoolAdmin {
+            messager: None,
+            client: None,
+        };
+
+        let mock_deployer = MockDeployer {};
+        let asserter = Asserter {};
+
+        let pool_admin = Agent::builder("pool_admin").with_behavior(pool_admin_behaviour);
+        let deployer = Agent::builder("mock_deployer").with_behavior(mock_deployer);
+        let asserter = Agent::builder("asserter").with_behavior(asserter);
+
+        world.add_agent(pool_admin);
+        world.add_agent(deployer);
+
+        world.run().await.expect("world failed to run");
+
+        let env = world.environment;
+        let mut world = World::new("univ3");
+
+        world.environment = env;
+
+        world.add_agent(asserter);
+
+        world.run().await.expect("world failed to run");
+    }
+}


### PR DESCRIPTION
Very interested in people's thoughts on this pattern - was kinda riffing.

Effectively have one world in which we simulate normal usage of behaviours, in this case `PoolAdmin`. We send a deploy request and deploy factory, pool and two mock tokens.

Have another world purely for test assertions, with the same environment as the first world. `Assertion` behaviour that checks assumptions about behaviours previous execution.

PR implements this as a test for the `PoolAdmin` behaviour.